### PR TITLE
Add entities pool_pump.next_run_start and pool_pump.next_run_stop with format

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ schedule taking into account the pool water temperature.
 * Splits the total target duration into two runs around the solar noon.
 1/3 before ans 2/3 after to allow filtering during the hottest part of the day.
 * You can add a customizable break between the two runs.
-* Initializes an entity (`pool_pump.schedule`) that shows the current or next
-  run of the pool pump.
+* Initializes the following entities:
+    * `pool_pump.next_run_schedule`: Pretty string of the scheduled current/next run.
+    * `pool_pump.next_run_start`: Starting datetime of the current/next run.
+    * `pool_pump.next_run_stop`: End datetime of the current/next run.
+    * `pool_pump.total_daily_filtering_duration`: Turn switch off.
 * Optional: Support for a water level sensor to specify an entity that indicates if the
   pool has reached a critical water level in which case the pool pump should
   not run at all.

--- a/custom_components/pool_pump/__init__.py
+++ b/custom_components/pool_pump/__init__.py
@@ -155,7 +155,7 @@ class PoolPumpManager:
 
         # TODO: check when the schedule for next day is computed
         noon = dt_util.as_local(
-            get_astral_event_date(self._hass, "solar_noon", self._now.date())
+            get_astral_event_date(self._hass, "noon", self._now.date())
         )
         _LOGGER.debug("Solar noon is at: {}".format(noon))
 

--- a/custom_components/pool_pump/__init__.py
+++ b/custom_components/pool_pump/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.core import Config, HomeAssistant
 
 from pypool_pump import AbacusFilteringDuration
+from pypool_pump import Run
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -164,12 +165,12 @@ class PoolPumpManager:
         # Create runs with a pivot on solar noon
         self._runs = self._pool_controler.update_schedule(noon)
 
-        # Add Run on sunset
-        sunset = dt_util.as_local(
-            get_astral_event_date(self._hass, "sunset", self._now.date())
+        # Add Run on sunrise
+        sunrise = dt_util.as_local(
+            get_astral_event_date(self._hass, "sunrise", self._now.date())
         )
-        sunset_run = Run(sunset, 1)
-        self._runs.insert(0,sunset_run)
+        sunrise_run = Run(sunrise, 1)
+        self._runs.insert(0,sunrise_run)
 
     def __repr__(self):
         """Return string representation of this feed."""

--- a/custom_components/pool_pump/__init__.py
+++ b/custom_components/pool_pump/__init__.py
@@ -117,10 +117,10 @@ async def async_setup(hass: HomeAssistant, config: Config):
                     _LOGGER.debug("Next run: %s", run)
                 schedule = run.pretty_print()
                 hass.states.async_set(
-                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_START), run.start_time
+                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_START), run.start_time.strftime('%Y-%m-%d, %H:%M')
                 )
                 hass.states.async_set(
-                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_STOP), run.stop_time
+                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_STOP), run.stop_time.strftime('%Y-%m-%d, %H:%M')
                 )
             # Set time range so that this can be displayed in the UI.
             hass.states.async_set(

--- a/custom_components/pool_pump/__init__.py
+++ b/custom_components/pool_pump/__init__.py
@@ -164,6 +164,13 @@ class PoolPumpManager:
         # Create runs with a pivot on solar noon
         self._runs = self._pool_controler.update_schedule(noon)
 
+        # Add Run on sunset
+        sunset = dt_util.as_local(
+            get_astral_event_date(self._hass, "sunset", self._now.date())
+        )
+        sunset_run = Run(sunset, 1)
+        self._runs.insert(0,sunset_run)
+
     def __repr__(self):
         """Return string representation of this feed."""
         return "<{}(runs={})>".format(self.__class__.__name__, self._runs)

--- a/custom_components/pool_pump/__init__.py
+++ b/custom_components/pool_pump/__init__.py
@@ -38,6 +38,8 @@ from .const import (
     ATTR_POOL_TEMPERATURE_ENTITY_ID,
     ATTR_TOTAL_DAILY_FILTERING_DURATION,
     ATTR_NEXT_RUN_SCHEDULE,
+    ATTR_NEXT_RUN_START,
+    ATTR_NEXT_RUN_STOP,
     ATTR_WATER_LEVEL_CRITICAL_ENTITY_ID,
     ATTR_SCHEDULE_BREAK_DURATION_IN_HOURS,
     DEFAULT_BREAK_DURATION_IN_HOURS,
@@ -114,6 +116,12 @@ async def async_setup(hass: HomeAssistant, config: Config):
                     run = manager_tomorrow.next_run()
                     _LOGGER.debug("Next run: %s", run)
                 schedule = run.pretty_print()
+                hass.states.async_set(
+                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_START), run.start_time
+                )
+                hass.states.async_set(
+                    "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_STOP), run.stop_time
+                )
             # Set time range so that this can be displayed in the UI.
             hass.states.async_set(
                 "{}.{}".format(DOMAIN, ATTR_NEXT_RUN_SCHEDULE), schedule

--- a/custom_components/pool_pump/const.py
+++ b/custom_components/pool_pump/const.py
@@ -3,7 +3,7 @@
 NAME = "Pool Pump Manager"
 DOMAIN = "pool_pump"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.2beta1"
+VERSION = "0.0.3beta1"
 
 ISSUE_URL = "https://github.com/oncleben31/ha-pool_pump/issues"
 DOC_URL = "https://github.com/oncleben31/ha-pool_pump"
@@ -22,6 +22,8 @@ ATTR_SWITCH_ENTITY_ID = "switch_entity_id"
 ATTR_POOL_TEMPERATURE_ENTITY_ID = "pool_temperature_entity_id"
 ATTR_TOTAL_DAILY_FILTERING_DURATION = "total_daily_filtering_duration"
 ATTR_NEXT_RUN_SCHEDULE = "next_run_schedule"
+ATTR_NEXT_RUN_START = "next_run_start"
+ATTR_NEXT_RUN_STOP = "next_run_stop"
 ATTR_SCHEDULE_BREAK_DURATION_IN_HOURS = "schedule_break_in_hours"
 DEFAULT_BREAK_DURATION_IN_HOURS = 0.0
 

--- a/custom_components/pool_pump/manifest.json
+++ b/custom_components/pool_pump/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "pool_pump",
   "name": "Pool Pump Manager",
+  "version": "0.0.3",
   "documentation": "https://github.com/oncleben31/ha-pool_pump",
   "dependencies": [],
   "config_flow": false,

--- a/info.md
+++ b/info.md
@@ -40,8 +40,11 @@ schedule taking into account the pool water temperature.
 * Splits the total target duration into two runs arround the solar noon.
 1/3 before ans 2/3 after to allow filtering during the hottest part of the day.
 * You can add a customisable break between the two runs.
-* Initialises an entity (`pool_pump.schedule`) that shows the current or next
-  run of the pool pump.
+* Initializes the following entities:
+    * `pool_pump.next_run_schedule`: Pretty string of the scheduled current/next run.
+    * `pool_pump.next_run_start`: Starting datetime of the current/next run.
+    * `pool_pump.next_run_stop`: End datetime of the current/next run.
+    * `pool_pump.total_daily_filtering_duration`: Turn switch off.
 * Optional: Support for a water level sensor to specify an entity that indicates if the
   pool has reached a critical water level in which case the pool pump should
   not run at all.


### PR DESCRIPTION
Hello, 
I added the entities `pool_pump.next_run_start` and `pool_pump.next_run_stop` 
based on the comment of @mycanaletto in this issue : https://github.com/oncleben31/ha-pool_pump/issues/9
Not 100% sure what kind of object  state can store (datetime, string ? advice is welcome )

Regards, 